### PR TITLE
refactor Attio MCP auth to proxy all bearer tokens

### DIFF
--- a/servers/attio/src/lib/base/api-client.ts
+++ b/servers/attio/src/lib/base/api-client.ts
@@ -13,13 +13,13 @@ export interface McpResponse {
 export async function makeAttioRequest(
   endpoint: string,
   options: RequestInit = {},
+  authToken?: string,
 ): Promise<any> {
   const baseUrl = process.env["ATTIO_API_BASE_URL"] || "https://api.attio.com";
-  const apiKey = process.env["ATTIO_API_KEY"];
 
-  if (!apiKey) {
+  if (!authToken) {
     throw new Error(
-      "ATTIO_API_KEY environment variable is required. Please set it in your .env.local file.",
+      "Authentication token is required. Please provide a valid Attio API key.",
     );
   }
 
@@ -27,7 +27,7 @@ export async function makeAttioRequest(
     const response = await fetch(`${baseUrl}${endpoint}`, {
       ...options,
       headers: {
-        Authorization: `Bearer ${apiKey}`,
+        Authorization: `Bearer ${authToken}`,
         "Content-Type": "application/json",
         ...options.headers,
       },

--- a/servers/attio/src/lib/scopes/attributes.ts
+++ b/servers/attio/src/lib/scopes/attributes.ts
@@ -129,10 +129,12 @@ export const updateStatusSchema = {
 export async function listAttributes(args: {
   target: string;
   identifier: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/${args.target}/${args.identifier}/attributes`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,
@@ -147,7 +149,7 @@ export async function createAttribute(args: {
   target: string;
   identifier: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/${args.target}/${args.identifier}/attributes`,
@@ -155,6 +157,7 @@ export async function createAttribute(args: {
         method: "POST",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -170,10 +173,12 @@ export async function getAttribute(args: {
   target: string;
   identifier: string;
   attribute: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/${args.target}/${args.identifier}/attributes/${args.attribute}`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,
@@ -189,7 +194,7 @@ export async function updateAttribute(args: {
   identifier: string;
   attribute: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/${args.target}/${args.identifier}/attributes/${args.attribute}`,
@@ -197,6 +202,7 @@ export async function updateAttribute(args: {
         method: "PATCH",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -213,10 +219,12 @@ export async function listSelectOptions(args: {
   target: string;
   identifier: string;
   attribute: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/${args.target}/${args.identifier}/attributes/${args.attribute}/options`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,
@@ -232,7 +240,7 @@ export async function createSelectOption(args: {
   identifier: string;
   attribute: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/${args.target}/${args.identifier}/attributes/${args.attribute}/options`,
@@ -240,6 +248,7 @@ export async function createSelectOption(args: {
         method: "POST",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -257,7 +266,7 @@ export async function updateSelectOption(args: {
   attribute: string;
   option: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/${args.target}/${args.identifier}/attributes/${args.attribute}/options/${args.option}`,
@@ -265,6 +274,7 @@ export async function updateSelectOption(args: {
         method: "PATCH",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -281,10 +291,12 @@ export async function listStatuses(args: {
   target: string;
   identifier: string;
   attribute: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/${args.target}/${args.identifier}/attributes/${args.attribute}/statuses`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,
@@ -300,7 +312,7 @@ export async function createStatus(args: {
   identifier: string;
   attribute: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/${args.target}/${args.identifier}/attributes/${args.attribute}/statuses`,
@@ -308,6 +320,7 @@ export async function createStatus(args: {
         method: "POST",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -325,7 +338,7 @@ export async function updateStatus(args: {
   attribute: string;
   status: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/${args.target}/${args.identifier}/attributes/${args.attribute}/statuses/${args.status}`,
@@ -333,6 +346,7 @@ export async function updateStatus(args: {
         method: "PATCH",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(

--- a/servers/attio/src/lib/scopes/comments.ts
+++ b/servers/attio/src/lib/scopes/comments.ts
@@ -60,6 +60,7 @@ export async function listThreads(
     entry_id?: string;
     limit?: number;
   } = {},
+  context?: { authToken?: string },
 ): Promise<McpResponse> {
   try {
     const queryParams = new URLSearchParams();
@@ -67,7 +68,7 @@ export async function listThreads(
     if (args.entry_id) queryParams.append("entry_id", args.entry_id);
     if (args.limit) queryParams.append("limit", args.limit.toString());
 
-    const response = await makeAttioRequest(`/v2/threads?${queryParams}`);
+    const response = await makeAttioRequest(`/v2/threads?${queryParams}`, {}, context?.authToken);
     return createMcpResponse(
       response,
       `Threads:\n\n${JSON.stringify(response, null, 2)}`,
@@ -79,9 +80,9 @@ export async function listThreads(
 
 export async function getThread(args: {
   thread_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
-    const response = await makeAttioRequest(`/v2/threads/${args.thread_id}`);
+    const response = await makeAttioRequest(`/v2/threads/${args.thread_id}`, {}, context?.authToken);
     return createMcpResponse(
       response,
       `Thread details:\n\n${JSON.stringify(response, null, 2)}`,
@@ -96,7 +97,7 @@ export async function createComment(args: {
   record_id?: string;
   entry_id?: string;
   thread_id?: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const { content, record_id, entry_id, thread_id } = args;
     let commentData: any = {
@@ -127,7 +128,7 @@ export async function createComment(args: {
       body: JSON.stringify({
         data: commentData,
       }),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -140,9 +141,9 @@ export async function createComment(args: {
 
 export async function getComment(args: {
   comment_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
-    const response = await makeAttioRequest(`/v2/comments/${args.comment_id}`);
+    const response = await makeAttioRequest(`/v2/comments/${args.comment_id}`, {}, context?.authToken);
     return createMcpResponse(
       response,
       `Comment details:\n\n${JSON.stringify(response, null, 2)}`,
@@ -154,11 +155,11 @@ export async function getComment(args: {
 
 export async function deleteComment(args: {
   comment_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     await makeAttioRequest(`/v2/comments/${args.comment_id}`, {
       method: "DELETE",
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       null,

--- a/servers/attio/src/lib/scopes/companies.ts
+++ b/servers/attio/src/lib/scopes/companies.ts
@@ -161,6 +161,7 @@ export const getCompanyEntriesSchema = {
 
 export async function searchCompanies(
   args: { query?: any } = {},
+  context?: { authToken?: string },
 ): Promise<McpResponse> {
   try {
     const { query = {} } = args;
@@ -187,6 +188,7 @@ export async function searchCompanies(
         method: "POST",
         body: JSON.stringify(requestBody),
       },
+      context?.authToken,
     );
 
     const companyCount = response.data?.length || 0;
@@ -208,10 +210,12 @@ export async function searchCompanies(
 
 export async function getCompany(args: {
   company_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/companies/records/${args.company_id}`,
+      {},
+      context?.authToken,
     );
 
     // Extract key information for better display
@@ -236,12 +240,12 @@ export async function getCompany(args: {
   }
 }
 
-export async function createCompany(args: { data: any }): Promise<McpResponse> {
+export async function createCompany(args: { data: any }, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(`/v2/objects/companies/records`, {
       method: "POST",
       body: JSON.stringify({ data: args.data }),
-    });
+    }, context?.authToken);
 
     const company = response.data;
     const summary = {
@@ -263,7 +267,7 @@ export async function createCompany(args: { data: any }): Promise<McpResponse> {
 export async function updateCompany(args: {
   company_id: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/companies/records/${args.company_id}`,
@@ -271,6 +275,7 @@ export async function updateCompany(args: {
         method: "PATCH",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     const company = response.data;
@@ -292,7 +297,7 @@ export async function updateCompany(args: {
 export async function assertCompany(args: {
   data: any;
   matching_attribute?: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const queryParams = new URLSearchParams();
     if (args.matching_attribute) {
@@ -308,6 +313,7 @@ export async function assertCompany(args: {
         method: "PUT",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     const company = response.data;
@@ -329,11 +335,11 @@ export async function assertCompany(args: {
 
 export async function deleteCompany(args: {
   company_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     await makeAttioRequest(`/v2/objects/companies/records/${args.company_id}`, {
       method: "DELETE",
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       { deleted: true, company_id: args.company_id },
@@ -351,7 +357,7 @@ export async function getCompanyAttributeValues(args: {
   show_historic?: boolean;
   limit?: number;
   offset?: number;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const queryParams = new URLSearchParams();
     if (args.show_historic) queryParams.append("show_historic", "true");
@@ -360,6 +366,8 @@ export async function getCompanyAttributeValues(args: {
 
     const response = await makeAttioRequest(
       `/v2/objects/companies/records/${args.company_id}/attributes/${args.attribute}/values?${queryParams}`,
+      {},
+      context?.authToken,
     );
 
     const valueCount = response.data?.length || 0;
@@ -384,7 +392,7 @@ export async function getCompanyEntries(args: {
   company_id: string;
   limit?: number;
   offset?: number;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const queryParams = new URLSearchParams();
     if (args.limit)
@@ -393,6 +401,8 @@ export async function getCompanyEntries(args: {
 
     const response = await makeAttioRequest(
       `/v2/objects/companies/records/${args.company_id}/entries?${queryParams}`,
+      {},
+      context?.authToken,
     );
 
     const entryCount = response.data?.length || 0;

--- a/servers/attio/src/lib/scopes/deals.ts
+++ b/servers/attio/src/lib/scopes/deals.ts
@@ -97,6 +97,7 @@ export const getDealEntriesSchema = {
 
 export async function searchDeals(
   args: { query?: any } = {},
+  context?: { authToken?: string },
 ): Promise<McpResponse> {
   try {
     const { query = {} } = args;
@@ -107,7 +108,7 @@ export async function searchDeals(
         limit: Math.min(query.limit || 25, 500),
         offset: query.offset || 0,
       }),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -118,10 +119,12 @@ export async function searchDeals(
   }
 }
 
-export async function getDeal(args: { deal_id: string }): Promise<McpResponse> {
+export async function getDeal(args: { deal_id: string }, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/deals/records/${args.deal_id}`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,
@@ -132,7 +135,7 @@ export async function getDeal(args: { deal_id: string }): Promise<McpResponse> {
   }
 }
 
-export async function createDeal(args: { data: any }): Promise<McpResponse> {
+export async function createDeal(args: { data: any }, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     // Ensure the data structure matches the API expectation
     const requestBody = {
@@ -144,7 +147,7 @@ export async function createDeal(args: { data: any }): Promise<McpResponse> {
     const response = await makeAttioRequest(`/v2/objects/deals/records`, {
       method: "POST",
       body: JSON.stringify(requestBody),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -158,7 +161,7 @@ export async function createDeal(args: { data: any }): Promise<McpResponse> {
 export async function updateDeal(args: {
   deal_id: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/deals/records/${args.deal_id}`,
@@ -166,6 +169,7 @@ export async function updateDeal(args: {
         method: "PATCH",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -177,12 +181,12 @@ export async function updateDeal(args: {
   }
 }
 
-export async function assertDeal(args: { data: any }): Promise<McpResponse> {
+export async function assertDeal(args: { data: any }, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(`/v2/objects/deals/records`, {
       method: "PUT",
       body: JSON.stringify(args.data),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -195,11 +199,11 @@ export async function assertDeal(args: { data: any }): Promise<McpResponse> {
 
 export async function deleteDeal(args: {
   deal_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     await makeAttioRequest(`/v2/objects/deals/records/${args.deal_id}`, {
       method: "DELETE",
-    });
+    }, context?.authToken);
 
     return createMcpResponse(null, `Successfully deleted deal ${args.deal_id}`);
   } catch (error) {
@@ -213,7 +217,7 @@ export async function getDealAttributeValues(args: {
   show_historic?: boolean;
   limit?: number;
   offset?: number;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const queryParams = new URLSearchParams();
     if (args.show_historic) queryParams.append("show_historic", "true");
@@ -222,6 +226,8 @@ export async function getDealAttributeValues(args: {
 
     const response = await makeAttioRequest(
       `/v2/objects/deals/records/${args.deal_id}/attributes/${args.attribute}/values?${queryParams}`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,
@@ -236,7 +242,7 @@ export async function getDealEntries(args: {
   deal_id: string;
   limit?: number;
   offset?: number;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const queryParams = new URLSearchParams();
     if (args.limit)
@@ -245,6 +251,8 @@ export async function getDealEntries(args: {
 
     const response = await makeAttioRequest(
       `/v2/objects/deals/records/${args.deal_id}/entries?${queryParams}`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,

--- a/servers/attio/src/lib/scopes/lists.ts
+++ b/servers/attio/src/lib/scopes/lists.ts
@@ -134,9 +134,9 @@ export const getListEntryAttributeValuesSchema = {
 // LISTS ACTIONS
 // ===============================
 
-export async function listLists(): Promise<McpResponse> {
+export async function listLists(context?: { authToken?: string }): Promise<McpResponse> {
   try {
-    const response = await makeAttioRequest("/v2/lists");
+    const response = await makeAttioRequest("/v2/lists", {}, context?.authToken);
     return createMcpResponse(
       response,
       `Lists in workspace:\n\n${JSON.stringify(response, null, 2)}`,
@@ -146,12 +146,12 @@ export async function listLists(): Promise<McpResponse> {
   }
 }
 
-export async function createList(args: { data: any }): Promise<McpResponse> {
+export async function createList(args: { data: any }, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest("/v2/lists", {
       method: "POST",
       body: JSON.stringify(args.data),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -162,9 +162,9 @@ export async function createList(args: { data: any }): Promise<McpResponse> {
   }
 }
 
-export async function getList(args: { list: string }): Promise<McpResponse> {
+export async function getList(args: { list: string }, context?: { authToken?: string }): Promise<McpResponse> {
   try {
-    const response = await makeAttioRequest(`/v2/lists/${args.list}`);
+    const response = await makeAttioRequest(`/v2/lists/${args.list}`, {}, context?.authToken);
     return createMcpResponse(
       response,
       `List details:\n\n${JSON.stringify(response, null, 2)}`,
@@ -177,12 +177,12 @@ export async function getList(args: { list: string }): Promise<McpResponse> {
 export async function updateList(args: {
   list: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(`/v2/lists/${args.list}`, {
       method: "PATCH",
       body: JSON.stringify(args.data),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -196,7 +196,7 @@ export async function updateList(args: {
 export async function searchListEntries(args: {
   list: string;
   query?: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const { list, query = {} } = args;
     const response = await makeAttioRequest(`/v2/lists/${list}/entries/query`, {
@@ -206,7 +206,7 @@ export async function searchListEntries(args: {
         offset: query.offset || 0,
         sorts: query.sorts || [],
       }),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -220,12 +220,12 @@ export async function searchListEntries(args: {
 export async function addToList(args: {
   list: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(`/v2/lists/${args.list}/entries`, {
       method: "POST",
       body: JSON.stringify(args.data),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -239,12 +239,12 @@ export async function addToList(args: {
 export async function upsertListEntry(args: {
   list: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(`/v2/lists/${args.list}/entries`, {
       method: "PUT",
       body: JSON.stringify(args.data),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -258,11 +258,11 @@ export async function upsertListEntry(args: {
 export async function removeFromList(args: {
   list: string;
   entry_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     await makeAttioRequest(`/v2/lists/${args.list}/entries/${args.entry_id}`, {
       method: "DELETE",
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       null,
@@ -276,10 +276,12 @@ export async function removeFromList(args: {
 export async function getListEntry(args: {
   list: string;
   entry_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/lists/${args.list}/entries/${args.entry_id}`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,
@@ -294,7 +296,7 @@ export async function updateListEntry(args: {
   list: string;
   entry_id: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/lists/${args.list}/entries/${args.entry_id}`,
@@ -302,6 +304,7 @@ export async function updateListEntry(args: {
         method: "PATCH",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -317,7 +320,7 @@ export async function putUpdateListEntry(args: {
   list: string;
   entry_id: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/lists/${args.list}/entries/${args.entry_id}`,
@@ -325,6 +328,7 @@ export async function putUpdateListEntry(args: {
         method: "PUT",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -341,13 +345,15 @@ export async function getListEntryAttributeValues(args: {
   entry_id: string;
   attribute: string;
   show_historic?: boolean;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const queryParams = new URLSearchParams();
     if (args.show_historic) queryParams.append("show_historic", "true");
 
     const response = await makeAttioRequest(
       `/v2/lists/${args.list}/entries/${args.entry_id}/attributes/${args.attribute}/values?${queryParams}`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,

--- a/servers/attio/src/lib/scopes/misc.ts
+++ b/servers/attio/src/lib/scopes/misc.ts
@@ -156,6 +156,7 @@ export const deleteWebhookSchema = {
 
 export async function searchUsers(
   args: { query?: any } = {},
+  context?: { authToken?: string },
 ): Promise<McpResponse> {
   try {
     const { query = {} } = args;
@@ -166,7 +167,7 @@ export async function searchUsers(
         offset: query.offset || 0,
         sorts: query.sorts || [],
       }),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -177,10 +178,12 @@ export async function searchUsers(
   }
 }
 
-export async function getUser(args: { user_id: string }): Promise<McpResponse> {
+export async function getUser(args: { user_id: string }, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/users/records/${args.user_id}`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,
@@ -191,12 +194,12 @@ export async function getUser(args: { user_id: string }): Promise<McpResponse> {
   }
 }
 
-export async function createUser(args: { data: any }): Promise<McpResponse> {
+export async function createUser(args: { data: any }, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(`/v2/objects/users/records`, {
       method: "POST",
       body: JSON.stringify(args.data),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -210,7 +213,7 @@ export async function createUser(args: { data: any }): Promise<McpResponse> {
 export async function updateUser(args: {
   user_id: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/users/records/${args.user_id}`,
@@ -218,6 +221,7 @@ export async function updateUser(args: {
         method: "PATCH",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -231,11 +235,11 @@ export async function updateUser(args: {
 
 export async function deleteUser(args: {
   user_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     await makeAttioRequest(`/v2/objects/users/records/${args.user_id}`, {
       method: "DELETE",
-    });
+    }, context?.authToken);
 
     return createMcpResponse(null, `Successfully deleted user ${args.user_id}`);
   } catch (error) {
@@ -249,6 +253,7 @@ export async function deleteUser(args: {
 
 export async function searchWorkspaces(
   args: { query?: any } = {},
+  context?: { authToken?: string },
 ): Promise<McpResponse> {
   try {
     const { query = {} } = args;
@@ -262,6 +267,7 @@ export async function searchWorkspaces(
           sorts: query.sorts || [],
         }),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -275,10 +281,12 @@ export async function searchWorkspaces(
 
 export async function getWorkspace(args: {
   workspace_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/workspaces/records/${args.workspace_id}`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,
@@ -291,12 +299,12 @@ export async function getWorkspace(args: {
 
 export async function createWorkspace(args: {
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(`/v2/objects/workspaces/records`, {
       method: "POST",
       body: JSON.stringify(args.data),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -310,7 +318,7 @@ export async function createWorkspace(args: {
 export async function updateWorkspace(args: {
   workspace_id: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/workspaces/records/${args.workspace_id}`,
@@ -318,6 +326,7 @@ export async function updateWorkspace(args: {
         method: "PATCH",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -331,13 +340,14 @@ export async function updateWorkspace(args: {
 
 export async function deleteWorkspace(args: {
   workspace_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     await makeAttioRequest(
       `/v2/objects/workspaces/records/${args.workspace_id}`,
       {
         method: "DELETE",
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -355,9 +365,9 @@ export async function deleteWorkspace(args: {
 
 export async function getMeeting(args: {
   meeting_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
-    const response = await makeAttioRequest(`/v2/meetings/${args.meeting_id}`);
+    const response = await makeAttioRequest(`/v2/meetings/${args.meeting_id}`, {}, context?.authToken);
     return createMcpResponse(
       response,
       `Meeting details:\n\n${JSON.stringify(response, null, 2)}`,
@@ -371,9 +381,9 @@ export async function getMeeting(args: {
 // WEBHOOKS ACTIONS
 // ===============================
 
-export async function listWebhooks(): Promise<McpResponse> {
+export async function listWebhooks(context?: { authToken?: string }): Promise<McpResponse> {
   try {
-    const response = await makeAttioRequest("/v2/webhooks");
+    const response = await makeAttioRequest("/v2/webhooks", {}, context?.authToken);
     return createMcpResponse(
       response,
       `Webhooks:\n\n${JSON.stringify(response, null, 2)}`,
@@ -383,12 +393,12 @@ export async function listWebhooks(): Promise<McpResponse> {
   }
 }
 
-export async function createWebhook(args: { data: any }): Promise<McpResponse> {
+export async function createWebhook(args: { data: any }, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest("/v2/webhooks", {
       method: "POST",
       body: JSON.stringify(args.data),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -401,9 +411,9 @@ export async function createWebhook(args: { data: any }): Promise<McpResponse> {
 
 export async function getWebhook(args: {
   webhook_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
-    const response = await makeAttioRequest(`/v2/webhooks/${args.webhook_id}`);
+    const response = await makeAttioRequest(`/v2/webhooks/${args.webhook_id}`, {}, context?.authToken);
     return createMcpResponse(
       response,
       `Webhook details:\n\n${JSON.stringify(response, null, 2)}`,
@@ -416,12 +426,12 @@ export async function getWebhook(args: {
 export async function updateWebhook(args: {
   webhook_id: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(`/v2/webhooks/${args.webhook_id}`, {
       method: "PATCH",
       body: JSON.stringify(args.data),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -434,11 +444,11 @@ export async function updateWebhook(args: {
 
 export async function deleteWebhook(args: {
   webhook_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     await makeAttioRequest(`/v2/webhooks/${args.webhook_id}`, {
       method: "DELETE",
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       null,

--- a/servers/attio/src/lib/scopes/notes.ts
+++ b/servers/attio/src/lib/scopes/notes.ts
@@ -44,13 +44,14 @@ export const deleteNoteSchema = {
 
 export async function listNotes(
   args: { record_id?: string; limit?: number } = {},
+  context?: { authToken?: string },
 ): Promise<McpResponse> {
   try {
     const queryParams = new URLSearchParams();
     if (args.record_id) queryParams.append("record_id", args.record_id);
     if (args.limit) queryParams.append("limit", args.limit.toString());
 
-    const response = await makeAttioRequest(`/v2/notes?${queryParams}`);
+    const response = await makeAttioRequest(`/v2/notes?${queryParams}`, {}, context?.authToken);
     return createMcpResponse(
       response,
       `Notes:\n\n${JSON.stringify(response, null, 2)}`,
@@ -60,9 +61,9 @@ export async function listNotes(
   }
 }
 
-export async function getNote(args: { note_id: string }): Promise<McpResponse> {
+export async function getNote(args: { note_id: string }, context?: { authToken?: string }): Promise<McpResponse> {
   try {
-    const response = await makeAttioRequest(`/v2/notes/${args.note_id}`);
+    const response = await makeAttioRequest(`/v2/notes/${args.note_id}`, {}, context?.authToken);
     return createMcpResponse(
       response,
       `Note details:\n\n${JSON.stringify(response, null, 2)}`,
@@ -77,7 +78,7 @@ export async function createNote(args: {
   content: string;
   title?: string;
   parent_object?: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const { record_id, content, title, parent_object = "people" } = args;
     const response = await makeAttioRequest("/v2/notes", {
@@ -91,7 +92,7 @@ export async function createNote(args: {
           content,
         },
       }),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -104,11 +105,11 @@ export async function createNote(args: {
 
 export async function deleteNote(args: {
   note_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     await makeAttioRequest(`/v2/notes/${args.note_id}`, {
       method: "DELETE",
-    });
+    }, context?.authToken);
 
     return createMcpResponse(null, `Successfully deleted note ${args.note_id}`);
   } catch (error) {

--- a/servers/attio/src/lib/scopes/objects.ts
+++ b/servers/attio/src/lib/scopes/objects.ts
@@ -61,9 +61,9 @@ export const getObjectAttributesSchema = {
 // OBJECTS ACTIONS
 // ===============================
 
-export async function listObjects(): Promise<McpResponse> {
+export async function listObjects(context?: { authToken?: string }): Promise<McpResponse> {
   try {
-    const response = await makeAttioRequest("/v2/objects");
+    const response = await makeAttioRequest("/v2/objects", {}, context?.authToken);
     return createMcpResponse(
       response,
       `Objects in workspace:\n\n${JSON.stringify(response, null, 2)}`,
@@ -75,9 +75,9 @@ export async function listObjects(): Promise<McpResponse> {
 
 export async function getObject(args: {
   object: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
-    const response = await makeAttioRequest(`/v2/objects/${args.object}`);
+    const response = await makeAttioRequest(`/v2/objects/${args.object}`, {}, context?.authToken);
     return createMcpResponse(
       response,
       `Object details:\n\n${JSON.stringify(response, null, 2)}`,
@@ -87,12 +87,12 @@ export async function getObject(args: {
   }
 }
 
-export async function createObject(args: { data: any }): Promise<McpResponse> {
+export async function createObject(args: { data: any }, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest("/v2/objects", {
       method: "POST",
       body: JSON.stringify(args.data),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -106,12 +106,12 @@ export async function createObject(args: { data: any }): Promise<McpResponse> {
 export async function updateObject(args: {
   object: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(`/v2/objects/${args.object}`, {
       method: "PATCH",
       body: JSON.stringify(args.data),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -124,10 +124,12 @@ export async function updateObject(args: {
 
 export async function getObjectAttributes(args: {
   object: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/${args.object}/attributes`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,

--- a/servers/attio/src/lib/scopes/people.ts
+++ b/servers/attio/src/lib/scopes/people.ts
@@ -64,6 +64,7 @@ export const deletePersonSchema = {
 
 export async function searchPeople(
   args: { query?: any } = {},
+  context?: { authToken?: string },
 ): Promise<McpResponse> {
   try {
     const { query = {} } = args;
@@ -77,6 +78,7 @@ export async function searchPeople(
           sorts: query.sorts || [],
         }),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -90,10 +92,12 @@ export async function searchPeople(
 
 export async function getPerson(args: {
   person_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/people/records/${args.person_id}`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,
@@ -104,12 +108,12 @@ export async function getPerson(args: {
   }
 }
 
-export async function createPerson(args: { data: any }): Promise<McpResponse> {
+export async function createPerson(args: { data: any }, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(`/v2/objects/people/records`, {
       method: "POST",
       body: JSON.stringify(args.data),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -123,7 +127,7 @@ export async function createPerson(args: { data: any }): Promise<McpResponse> {
 export async function updatePerson(args: {
   person_id: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/people/records/${args.person_id}`,
@@ -131,6 +135,7 @@ export async function updatePerson(args: {
         method: "PATCH",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -144,11 +149,11 @@ export async function updatePerson(args: {
 
 export async function deletePerson(args: {
   person_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     await makeAttioRequest(`/v2/objects/people/records/${args.person_id}`, {
       method: "DELETE",
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       null,

--- a/servers/attio/src/lib/scopes/records.ts
+++ b/servers/attio/src/lib/scopes/records.ts
@@ -115,7 +115,7 @@ export const getRecordEntriesSchema = {
 export async function searchRecords(args: {
   object: string;
   query?: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const { object, query = {} } = args;
     const response = await makeAttioRequest(
@@ -128,6 +128,7 @@ export async function searchRecords(args: {
           sorts: query.sorts || [],
         }),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -142,10 +143,12 @@ export async function searchRecords(args: {
 export async function getRecord(args: {
   object: string;
   record_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/${args.object}/records/${args.record_id}`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,
@@ -159,7 +162,7 @@ export async function getRecord(args: {
 export async function createRecord(args: {
   object: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/${args.object}/records`,
@@ -167,6 +170,7 @@ export async function createRecord(args: {
         method: "POST",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -182,7 +186,7 @@ export async function updateRecord(args: {
   object: string;
   record_id: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/${args.object}/records/${args.record_id}`,
@@ -190,6 +194,7 @@ export async function updateRecord(args: {
         method: "PATCH",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -205,7 +210,7 @@ export async function putUpdateRecord(args: {
   object: string;
   record_id: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/${args.object}/records/${args.record_id}`,
@@ -213,6 +218,7 @@ export async function putUpdateRecord(args: {
         method: "PUT",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -227,7 +233,7 @@ export async function putUpdateRecord(args: {
 export async function upsertRecord(args: {
   object: string;
   data: any;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/${args.object}/records`,
@@ -235,6 +241,7 @@ export async function upsertRecord(args: {
         method: "PUT",
         body: JSON.stringify(args.data),
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -249,13 +256,14 @@ export async function upsertRecord(args: {
 export async function deleteRecord(args: {
   object: string;
   record_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     await makeAttioRequest(
       `/v2/objects/${args.object}/records/${args.record_id}`,
       {
         method: "DELETE",
       },
+      context?.authToken,
     );
 
     return createMcpResponse(
@@ -272,13 +280,15 @@ export async function getRecordAttributeValues(args: {
   record_id: string;
   attribute: string;
   show_historic?: boolean;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const queryParams = new URLSearchParams();
     if (args.show_historic) queryParams.append("show_historic", "true");
 
     const response = await makeAttioRequest(
       `/v2/objects/${args.object}/records/${args.record_id}/attributes/${args.attribute}/values?${queryParams}`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,
@@ -292,10 +302,12 @@ export async function getRecordAttributeValues(args: {
 export async function getRecordEntries(args: {
   object: string;
   record_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/objects/${args.object}/records/${args.record_id}/entries`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,

--- a/servers/attio/src/lib/scopes/tasks.ts
+++ b/servers/attio/src/lib/scopes/tasks.ts
@@ -70,6 +70,7 @@ export async function listTasks(
     is_completed?: boolean;
     limit?: number;
   } = {},
+  context?: { authToken?: string },
 ): Promise<McpResponse> {
   try {
     const queryParams = new URLSearchParams();
@@ -78,7 +79,7 @@ export async function listTasks(
       queryParams.append("is_completed", args.is_completed.toString());
     if (args.limit) queryParams.append("limit", args.limit.toString());
 
-    const response = await makeAttioRequest(`/v2/tasks?${queryParams}`);
+    const response = await makeAttioRequest(`/v2/tasks?${queryParams}`, {}, context?.authToken);
     return createMcpResponse(
       response,
       `Tasks:\n\n${JSON.stringify(response, null, 2)}`,
@@ -88,9 +89,9 @@ export async function listTasks(
   }
 }
 
-export async function getTask(args: { task_id: string }): Promise<McpResponse> {
+export async function getTask(args: { task_id: string }, context?: { authToken?: string }): Promise<McpResponse> {
   try {
-    const response = await makeAttioRequest(`/v2/tasks/${args.task_id}`);
+    const response = await makeAttioRequest(`/v2/tasks/${args.task_id}`, {}, context?.authToken);
     return createMcpResponse(
       response,
       `Task details:\n\n${JSON.stringify(response, null, 2)}`,
@@ -105,7 +106,7 @@ export async function createTask(args: {
   assignee_id?: string;
   deadline_at?: string;
   linked_records?: string[];
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const { content, assignee_id, deadline_at, linked_records = [] } = args;
     const assignees = assignee_id
@@ -132,7 +133,7 @@ export async function createTask(args: {
           assignees,
         },
       }),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -149,13 +150,13 @@ export async function updateTask(args: {
   deadline_at?: string;
   assignees?: any[];
   linked_records?: any[];
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const { task_id, ...updateData } = args;
     const response = await makeAttioRequest(`/v2/tasks/${task_id}`, {
       method: "PATCH",
       body: JSON.stringify(updateData),
-    });
+    }, context?.authToken);
 
     return createMcpResponse(
       response,
@@ -168,11 +169,11 @@ export async function updateTask(args: {
 
 export async function deleteTask(args: {
   task_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     await makeAttioRequest(`/v2/tasks/${args.task_id}`, {
       method: "DELETE",
-    });
+    }, context?.authToken);
 
     return createMcpResponse(null, `Successfully deleted task ${args.task_id}`);
   } catch (error) {

--- a/servers/attio/src/lib/scopes/test.ts
+++ b/servers/attio/src/lib/scopes/test.ts
@@ -15,6 +15,7 @@ export const testConnectionSchema = {
 
 export async function testConnection(
   args: { message?: string } = {},
+  context?: { authToken?: string },
 ): Promise<McpResponse> {
   const { message } = args;
   return {

--- a/servers/attio/src/lib/scopes/workspace.ts
+++ b/servers/attio/src/lib/scopes/workspace.ts
@@ -26,13 +26,13 @@ export const getSelfSchema = {};
 // WORKSPACE ACTIONS
 // ===============================
 
-export async function introspectWorkspace(): Promise<McpResponse> {
+export async function introspectWorkspace(context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const [self, objects, lists, members] = await Promise.all([
-      makeAttioRequest("/v2/self"),
-      makeAttioRequest("/v2/objects"),
-      makeAttioRequest("/v2/lists"),
-      makeAttioRequest("/v2/workspace_members"),
+      makeAttioRequest("/v2/self", {}, context?.authToken),
+      makeAttioRequest("/v2/objects", {}, context?.authToken),
+      makeAttioRequest("/v2/lists", {}, context?.authToken),
+      makeAttioRequest("/v2/workspace_members", {}, context?.authToken),
     ]);
 
     const workspaceInfo = {
@@ -56,9 +56,9 @@ export async function introspectWorkspace(): Promise<McpResponse> {
   }
 }
 
-export async function getWorkspaceMembers(): Promise<McpResponse> {
+export async function getWorkspaceMembers(context?: { authToken?: string }): Promise<McpResponse> {
   try {
-    const response = await makeAttioRequest("/v2/workspace_members");
+    const response = await makeAttioRequest("/v2/workspace_members", {}, context?.authToken);
     return createMcpResponse(
       response,
       `Workspace Members:\n\n${JSON.stringify(response, null, 2)}`,
@@ -70,10 +70,12 @@ export async function getWorkspaceMembers(): Promise<McpResponse> {
 
 export async function getWorkspaceMember(args: {
   workspace_member_id: string;
-}): Promise<McpResponse> {
+}, context?: { authToken?: string }): Promise<McpResponse> {
   try {
     const response = await makeAttioRequest(
       `/v2/workspace_members/${args.workspace_member_id}`,
+      {},
+      context?.authToken,
     );
     return createMcpResponse(
       response,
@@ -84,9 +86,9 @@ export async function getWorkspaceMember(args: {
   }
 }
 
-export async function getSelf(): Promise<McpResponse> {
+export async function getSelf(context?: { authToken?: string }): Promise<McpResponse> {
   try {
-    const response = await makeAttioRequest("/v2/self");
+    const response = await makeAttioRequest("/v2/self", {}, context?.authToken);
     return createMcpResponse(
       response,
       `Self information:\n\n${JSON.stringify(response, null, 2)}`,


### PR DESCRIPTION
- Refactored authentication system - Replaced custom authentication middleware with
  the `@vercel/mcp-adapter`'s experimental auth system
- Modified API client - Updated makeAttioRequest to accept auth token as parameter
  instead of using environment variable
- Updated all scope functions - Added optional context parameter with auth token to
  all 13 scope files (attributes, comments, companies, deals, lists, misc, notes,
  objects, people, records, tasks, test, workspace)
- Enhanced function signatures - All functions now accept context?: { authToken?:
  string } as second parameter
- Bearer token authentication - Implemented proper token-based auth using MCP's
  built-in auth system
- Removed legacy auth - Eliminated custom authentication logic and environment-based
  API key handling